### PR TITLE
Show current internet radio station name

### DIFF
--- a/PioneerDesktopControl/MainWindow.xaml
+++ b/PioneerDesktopControl/MainWindow.xaml
@@ -68,12 +68,16 @@
 
         </UniformGrid>
 
-        <DockPanel x:Name="InfoPanel" DockPanel.Dock="Top">
-            <Label x:Name="infoLabel" 
-                   Content="additional information" 
+        <StackPanel x:Name="InfoPanel" DockPanel.Dock="Top">
+            <Label x:Name="StationNameLabel"
+                   Content="Station: -"
                    FontSize="16"
-                   HorizontalAlignment="Left"/>                
-        </DockPanel>
+                   HorizontalAlignment="Left"/>
+            <Label x:Name="infoLabel"
+                   Content="additional information"
+                   FontSize="16"
+                   HorizontalAlignment="Left"/>
+        </StackPanel>
             
         
 

--- a/PioneerDesktopControl/MainWindow.xaml.cs
+++ b/PioneerDesktopControl/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ namespace PioneerDesktopControl
 
         const string RegRadioIPAddress = "Radio IP address";
         const string RegLocation = "Sintaj\\PioneerDesktopControl";
+        const string StationNamePrefix = "Station: ";
 
 
         private bool LoadRegSettings()
@@ -102,6 +103,17 @@ namespace PioneerDesktopControl
             {
                 await TelnetClient.Write("\r\n?V\r\n");
             }
+        }
+
+        private void SetStationName(string stationName)
+        {
+            if (string.IsNullOrWhiteSpace(stationName))
+            {
+                StationNameLabel.Content = StationNamePrefix + "-";
+                return;
+            }
+
+            StationNameLabel.Content = StationNamePrefix + stationName.Trim();
         }
 
 
@@ -202,7 +214,7 @@ namespace PioneerDesktopControl
 
                 else if (msg.IndexOf("GEP02020") >= 0)  // GEP02020 is Station name
                 {
-                    infoLabel.Content = msg.Substring(8).Replace("\"", "") + " (" + infoLabel.Content + ")";
+                    SetStationName(msg.Substring(8).Replace("\"", ""));
                 }
 
                 else if ((msg.IndexOf("GEP") >= 0) && (msg[5] == '1')) // 5. bit means active menu item
@@ -247,21 +259,25 @@ namespace PioneerDesktopControl
                 {
                     playerCMDs = new CD_PlayerCMDs();
                     infoLabel.Content = "CD player is active";
+                    SetStationName(null);
                 }
                 else if (msg.CompareTo("FN02") == 0)
                 {
                     playerCMDs = new RADIO_PlayerCMDs();
                     infoLabel.Content = "Radio active";
+                    SetStationName(null);
                 }
                 else if (msg.CompareTo("FN38") == 0)
                 {
                     playerCMDs = new Internet_PlayerCMDs();
                     infoLabel.Content = "Internet radio is active";
+                    SetStationName("Loading...");
                 }
                 else if (msg.CompareTo("FN17") == 0)
                 {
                     playerCMDs = new USB_PlayerCMDs();
                     infoLabel.Content = "USB player is active";
+                    SetStationName(null);
                 }
 
                 msg = ""; // sometimes, there is no end of line character in msg (likely due to timeout). Message was processed, so clean it.
@@ -505,7 +521,7 @@ namespace PioneerDesktopControl
             // RadioStationPanel.Visibility = vis;
             RadioStationPanel2.Visibility = vis;
             VolValueLabel.Visibility = vis;
-            infoLabel.Visibility = vis;
+            InfoPanel.Visibility = vis;
 
         }
 


### PR DESCRIPTION
### Motivation
- Users need to see the currently-playing Internet radio station name separately from other informational text in the UI. 
- The radio sends station name in `GEP02020` messages and the app should surface that in the main window.

### Description
- Added a dedicated `StationNameLabel` in `MainWindow.xaml` inside a new `InfoPanel` stack so the station name is shown above other info text. 
- Implemented `SetStationName(string)` in `MainWindow.xaml.cs` to update the label and to show a default `"Station: -"` when empty. 
- Updated telnet message handling to populate the station name from `GEP02020` messages and to set `"Loading..."` when switching to Internet Radio (`FN38`). 
- Reset the station label to empty when switching to other functions and made the entire `InfoPanel` visibility follow the main GUI visibility logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a4cb8404832192574ce880e03b74)